### PR TITLE
Update PropPatch namespace

### DIFF
--- a/WebDava/ApiHandlers/PropPatchHandler.cs
+++ b/WebDava/ApiHandlers/PropPatchHandler.cs
@@ -4,7 +4,7 @@ using System.Xml.Schema;
 using WebDava;
 using WebDava.Helpers;
 
-namespace WebDAVSharp.ApiHandlers;
+namespace WebDava.ApiHandlers;
 
 public static class PropPatchHandler
 {

--- a/WebDava/Program.cs
+++ b/WebDava/Program.cs
@@ -5,7 +5,6 @@ using Serilog.Events;
 using WebDava.ApiHandlers;
 using WebDava.Configurations;
 using WebDava.Repositories;
-using WebDAVSharp.ApiHandlers;
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
## Summary
- update `PropPatchHandler` namespace to match other handlers
- remove obsolete `using` from `Program.cs`

## Testing
- `dotnet build WebDava.sln -v minimal` *(fails: `dotnet: command not found`)*