### PR TITLE
Fix listing path usage

### DIFF
--- a/WebDava/Repositories/FileStorageRepository.cs
+++ b/WebDava/Repositories/FileStorageRepository.cs
@@ -153,12 +153,12 @@ public class FileStorageRepository(StorageOptions options) : IStorageRepository
 
         var sPath = path.AsFullPath(options);
 
-        if (!Directory.Exists(path))
+        if (!Directory.Exists(sPath))
         {
             throw new DirectoryNotFoundException("The specified directory does not exist.");
         }
 
-        var directoryInfo = new DirectoryInfo(path);
+        var directoryInfo = new DirectoryInfo(sPath);
         var resources = directoryInfo.EnumerateFiles().Select(info => info.AsResourceInfo());
 
         return await Task.FromResult(resources);


### PR DESCRIPTION
## Summary
- ensure directory checks use the full path when listing resources

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*