### PR TITLE
Handle save failure in PUT handler

### DIFF
--- a/WebDava/ApiHandlers/PutHandler.cs
+++ b/WebDava/ApiHandlers/PutHandler.cs
@@ -21,7 +21,14 @@ public static class PutHandler
             var bodyReader = context.Request.BodyReader; // 1 MB limit
 
             var storageRepository = context.RequestServices.GetRequiredService<IStorageRepository>();
-            await storageRepository.SaveResource(path, bodyReader, cancellationToken);
+            var result = await storageRepository.SaveResource(path, bodyReader, cancellationToken);
+
+            if (result.IsFailure)
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                await context.Response.WriteAsync(result.Error ?? "Failed to save resource.");
+                return;
+            }
 
             if(cancellationToken.IsCancellationRequested)
             {


### PR DESCRIPTION
## Summary
- check the result from `SaveResource` in the PUT handler
- send 500 with the error message when saving fails

## Testing
- `dotnet --version` *(fails: command not found)*