### PR TITLE
Replace Response.Body.Close with CompleteAsync

### DIFF
--- a/WebDava/ApiHandlers/GetHandler.cs
+++ b/WebDava/ApiHandlers/GetHandler.cs
@@ -40,6 +40,6 @@ public static class GetHandler
         //await context.Response.SendFileAsync(stream, cancellationToken);
         await StreamCopyOperation.CopyToAsync(stream, context.Response.Body, stream.Length, StreamCopyBufferSize, cancellationToken);
 
-        context.Response.Body.Close();
+        await context.Response.CompleteAsync();
     }
 }


### PR DESCRIPTION
## Summary
- use `await context.Response.CompleteAsync()` instead of closing the body in `GetHandler`

## Testing
- `dotnet build WebDava.sln` *(fails: command not found)*