### PR TITLE
Fix Content-Type header in HeadHandler

### DIFF
--- a/WebDava/ApiHandlers/HeadHandler.cs
+++ b/WebDava/ApiHandlers/HeadHandler.cs
@@ -26,7 +26,7 @@ public static class HeadHandler
         }
 
         context.Response.StatusCode = StatusCodes.Status200OK;
-        context.Response.Headers.Append("Content-Type", resource.ContentType); // Adjust MIME type as needed
+        context.Response.Headers.Append("Content-Type", resource.ContentType ?? MimeTypeHelper.GetMimeType(resource.Extension));
         context.Response.Headers.Append("Content-Length", resource.Length.ToString());
         context.Response.Headers.Append("Last-Modified", resource.LastWriteTimeUtc.ToString("R"));
         context.Response.Headers.Append("ETag", resource.ETag);


### PR DESCRIPTION
## Summary
- return a default MIME type if `resource.ContentType` is null when handling HEAD

## Testing
- `dotnet build WebDava.sln -v minimal` *(fails: `dotnet` not installed)*