### PR TITLE
Add xUnit tests

### DIFF
--- a/WebDava.sln
+++ b/WebDava.sln
@@ -1,8 +1,12 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebDava", "WebDava\WebDava.csproj", "{95BCF460-FC5E-FD12-4E86-E8DD8EF786F4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{AE5F00F2-7C09-4503-97C2-3907539400CE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebDava.Tests", "tests\WebDava.Tests\WebDava.Tests.csproj", "{8FFF94C4-FDCC-4D93-9068-167F9B8FF368}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,11 +18,18 @@ Global
 		{95BCF460-FC5E-FD12-4E86-E8DD8EF786F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95BCF460-FC5E-FD12-4E86-E8DD8EF786F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95BCF460-FC5E-FD12-4E86-E8DD8EF786F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8FFF94C4-FDCC-4D93-9068-167F9B8FF368}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FFF94C4-FDCC-4D93-9068-167F9B8FF368}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FFF94C4-FDCC-4D93-9068-167F9B8FF368}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FFF94C4-FDCC-4D93-9068-167F9B8FF368}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {67AED796-AA22-4E87-BA82-9C08D37F8E9D}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8FFF94C4-FDCC-4D93-9068-167F9B8FF368} = {AE5F00F2-7C09-4503-97C2-3907539400CE}
 	EndGlobalSection
 EndGlobal

--- a/tests/WebDava.Tests/FilePathExtensionsTests.cs
+++ b/tests/WebDava.Tests/FilePathExtensionsTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using WebDava;
+using WebDava.Configurations;
+
+namespace WebDava.Tests;
+
+public class FilePathExtensionsTests
+{
+    [Fact]
+    public void IsFullPath_WithFullPath_ReturnsTrue()
+    {
+        var fullPath = Path.Combine(Path.GetTempPath(), "file.txt");
+        FilePathExtensions.IsFullPath(fullPath).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AsFullPath_WithRelativePath_CombinesStoragePath()
+    {
+        var options = new StorageOptions { StoragePath = "/root" };
+        var result = "data/file.txt".AsFullPath(options);
+        result.Should().Be(Path.Combine(options.StoragePath, "data/file.txt"));
+    }
+}

--- a/tests/WebDava.Tests/GlobalUsings.cs
+++ b/tests/WebDava.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/WebDava.Tests/WebDava.Tests.csproj
+++ b/tests/WebDava.Tests/WebDava.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebDava\WebDava.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add xUnit test project
- cover FilePathExtensions with simple tests

## Testing
- `dotnet restore` *(fails: Unable to load the service index for nuget.org)*
- `dotnet test --no-restore` *(fails: project.assets.json not found)*